### PR TITLE
Implement getPrice with MockDriver

### DIFF
--- a/TDD4_TradingSystme/StockerBroker.cpp
+++ b/TDD4_TradingSystme/StockerBroker.cpp
@@ -4,6 +4,10 @@
 
 using std::string;
 
+struct Driver {
+  virtual int getPrice(int stockCode) = 0;
+};
+
 class IStockBroker
 {
 public:
@@ -15,7 +19,7 @@ public:
     virtual bool login(string id, string pw) = 0;
     virtual bool buy(int stockCode, int price, int qty) = 0;
     virtual bool sell(int stockCode, int price, int qty) = 0;
-    virtual bool getPrice(int stockCode) = 0;
+    virtual int getPrice(int stockCode) = 0;
     virtual string getID() = 0;
 };
 
@@ -41,12 +45,20 @@ public:
     bool login(string id, string pw) { return false; }
     bool buy(int stockCode, int price, int qty) { return false; }
     bool sell(int stockCode, int price, int qty) { return false; }
-    bool getPrice(int stockCode) { return false; }
+
+    int getPrice(int stockCode) {
+      return driver->getPrice(stockCode);
+    }
+
     string getID() {
         return ID;
     }
 
+    void setDriver(Driver* driver) {
+      this->driver = driver;
+    }
+
 private:
     string ID;
-
+    Driver* driver;
 };

--- a/TDD4_TradingSystme/test.cpp
+++ b/TDD4_TradingSystme/test.cpp
@@ -186,7 +186,7 @@ TEST_F(TradingSystemFixture, GetPrice_Kiwer_Fail_Invalid_Code) {
 	brokerManager.setDriver(&mockDriver);
 
 	// act
-	brokerManager.selectStockBrocker(KIWER);
+	brokerManager.selectStockBroker(KIWER);
 	int actual = brokerManager.getPrice(INVALID_CODE);
 
 
@@ -204,7 +204,7 @@ TEST_F(TradingSystemFixture, GetPrice_Kiwer_Success) {
 	brokerManager.setDriver(&mockDriver);
 
 	// act
-	brokerManager.selectStockBrocker(KIWER);
+	brokerManager.selectStockBroker(KIWER);
 	int actual = brokerManager.getPrice(STOCK_CODE);
 
 
@@ -224,7 +224,7 @@ TEST_F(TradingSystemFixture, GetPrice_Nemo_Fail_Invalid_Code) {
 	brokerManager.setDriver(&mockDriver);
 
 	// act
-	brokerManager.selectStockBrocker(NEMO);
+	brokerManager.selectStockBroker(NEMO);
 	int actual = brokerManager.getPrice(INVALID_CODE);
 
 
@@ -242,7 +242,7 @@ TEST_F(TradingSystemFixture, GetPrice_Nemo_Success) {
 	brokerManager.setDriver(&mockDriver);
 
 	// act
-	brokerManager.selectStockBrocker(NEMO);
+	brokerManager.selectStockBroker(NEMO);
 	int actual = brokerManager.getPrice(STOCK_CODE);
 
 

--- a/TDD4_TradingSystme/test.cpp
+++ b/TDD4_TradingSystme/test.cpp
@@ -23,6 +23,13 @@ public:
 	const string NEMO = "NEMO";
 	const string USER = "USER";
 	const string PASSWORD = "PASSWORD";
+	const int INVALID_CODE = 0;
+	const int STOCK_CODE = 1;
+	const int PRICE = 10000;
+	const int QUANTITY = 10;
+	const int ZERO = 0;
+	const int OVER = 10000;
+
 
 	StockMock stockmock;
 
@@ -159,4 +166,49 @@ TEST_F(TradingSystemFixture, Login_Nemo_Fail_Invalid_Password) {
 TEST_F(TradingSystemFixture, Login_Nemo_Success) {
 	std::string loginMsg = getLoginMsg(true, NEMO, USER, PASSWORD);
 	EXPECT_EQ(loginMsg, getNemoLoginMsg(USER, PASSWORD));
+}
+
+///////////////     5. Get Price     ///////////////
+
+/// 5.1 KIWER
+TEST_F(TradingSystemFixture, GetPrice_Kiwer_Fail_Invalid_Code) {
+	EXPECT_CALL(stockmock, getPrice)
+		.Times(1)
+		.WillOnce(Return(ZERO));
+
+	stockmock.selectStockBrocker(KIWER);
+
+	EXPECT_EQ(stockmock.getPrice(INVALID_CODE), ZERO);
+}
+
+TEST_F(TradingSystemFixture, GetPrice_Kiwer_Success) {
+	EXPECT_CALL(stockmock, getPrice)
+		.Times(1)
+		.WillOnce(Return(PRICE));
+
+	stockmock.selectStockBrocker(KIWER);
+
+	EXPECT_EQ(stockmock.getPrice(STOCK_CODE), PRICE);
+}
+
+
+/// 5.2 NEMO
+TEST_F(TradingSystemFixture, GetPrice_Nemo_Fail_Invalid_Code) {
+	EXPECT_CALL(stockmock, getPrice)
+		.Times(1)
+		.WillOnce(Return(ZERO));
+
+	stockmock.selectStockBrocker(NEMO);
+
+	EXPECT_EQ(stockmock.getPrice(INVALID_CODE), 0);
+}
+
+TEST_F(TradingSystemFixture, GetPrice_Nemo_Success) {
+	EXPECT_CALL(stockmock, getPrice)
+		.Times(1)
+		.WillOnce(Return(PRICE));
+
+	stockmock.selectStockBrocker(NEMO);
+
+	EXPECT_EQ(stockmock.getPrice(STOCK_CODE), PRICE);
 }

--- a/TDD4_TradingSystme/test.cpp
+++ b/TDD4_TradingSystme/test.cpp
@@ -12,8 +12,13 @@ public:
 	MOCK_METHOD(bool, login, (string id, string pw), (override));
 	MOCK_METHOD(bool, buy, (int stockCode, int price, int qty), (override));
 	MOCK_METHOD(bool, sell, (int stockCode, int price, int qty), (override));
-	MOCK_METHOD(bool, getPrice, (int stockCode), (override));
+	MOCK_METHOD(int, getPrice, (int stockCode), (override));
 	MOCK_METHOD(string, getID, (), (override));
+};
+
+class MockDriver : public Driver {
+public:
+	MOCK_METHOD(int, getPrice, (int), (override));
 };
 
 class TradingSystemFixture : public Test {
@@ -172,43 +177,75 @@ TEST_F(TradingSystemFixture, Login_Nemo_Success) {
 
 /// 5.1 KIWER
 TEST_F(TradingSystemFixture, GetPrice_Kiwer_Fail_Invalid_Code) {
-	EXPECT_CALL(stockmock, getPrice)
-		.Times(1)
-		.WillOnce(Return(ZERO));
+	// arrange
+	NiceMock<MockDriver> mockDriver;
+	EXPECT_CALL(mockDriver, getPrice(INVALID_CODE))
+		.WillRepeatedly(Return(ZERO));
 
-	stockmock.selectStockBrocker(KIWER);
+	BrokerManager brokerManager;
+	brokerManager.setDriver(&mockDriver);
 
-	EXPECT_EQ(stockmock.getPrice(INVALID_CODE), ZERO);
+	// act
+	brokerManager.selectStockBrocker(KIWER);
+	int actual = brokerManager.getPrice(INVALID_CODE);
+
+
+	// assert
+	EXPECT_EQ(actual, ZERO);
 }
 
 TEST_F(TradingSystemFixture, GetPrice_Kiwer_Success) {
-	EXPECT_CALL(stockmock, getPrice)
-		.Times(1)
-		.WillOnce(Return(PRICE));
+	// arrange
+	NiceMock<MockDriver> mockDriver;
+	EXPECT_CALL(mockDriver, getPrice(STOCK_CODE))
+		.WillRepeatedly(Return(PRICE));
 
-	stockmock.selectStockBrocker(KIWER);
+	BrokerManager brokerManager;
+	brokerManager.setDriver(&mockDriver);
 
-	EXPECT_EQ(stockmock.getPrice(STOCK_CODE), PRICE);
+	// act
+	brokerManager.selectStockBrocker(KIWER);
+	int actual = brokerManager.getPrice(STOCK_CODE);
+
+
+	// assert
+	EXPECT_EQ(actual, PRICE);
 }
 
 
 /// 5.2 NEMO
 TEST_F(TradingSystemFixture, GetPrice_Nemo_Fail_Invalid_Code) {
-	EXPECT_CALL(stockmock, getPrice)
-		.Times(1)
-		.WillOnce(Return(ZERO));
+	// arrange
+	NiceMock<MockDriver> mockDriver;
+	EXPECT_CALL(mockDriver, getPrice(INVALID_CODE))
+		.WillRepeatedly(Return(ZERO));
 
-	stockmock.selectStockBrocker(NEMO);
+	BrokerManager brokerManager;
+	brokerManager.setDriver(&mockDriver);
 
-	EXPECT_EQ(stockmock.getPrice(INVALID_CODE), 0);
+	// act
+	brokerManager.selectStockBrocker(NEMO);
+	int actual = brokerManager.getPrice(INVALID_CODE);
+
+
+	// assert
+	EXPECT_EQ(actual, ZERO);
 }
 
 TEST_F(TradingSystemFixture, GetPrice_Nemo_Success) {
-	EXPECT_CALL(stockmock, getPrice)
-		.Times(1)
-		.WillOnce(Return(PRICE));
+	// arrange
+	NiceMock<MockDriver> mockDriver;
+	EXPECT_CALL(mockDriver, getPrice(STOCK_CODE))
+		.WillRepeatedly(Return(PRICE));
 
-	stockmock.selectStockBrocker(NEMO);
+	BrokerManager brokerManager;
+	brokerManager.setDriver(&mockDriver);
 
-	EXPECT_EQ(stockmock.getPrice(STOCK_CODE), PRICE);
+	// act
+	brokerManager.selectStockBrocker(NEMO);
+	int actual = brokerManager.getPrice(STOCK_CODE);
+
+
+	// assert
+	EXPECT_EQ(actual, PRICE);
 }


### PR DESCRIPTION
이 PR은 TradingSystem의 현재가 확인 기능(`getPrice()`)을 구현합니다.

키워 Driver와 네모 Driver는 추후에 들여올 예정이므로,
테스트를 위해서 우선 MockDriver를 도입했습니다.

해당 MockDriver는 기타 기능에도 적용이 가능하나, 기능 분리를 위해 `getPrice`에만 유효하도록 최소한으로 구현해서 넣었습니다.
확인 부탁드립니다.